### PR TITLE
Jumbo doesn't work for S (assembler) files

### DIFF
--- a/tools/gn/header_checker.cc
+++ b/tools/gn/header_checker.cc
@@ -582,6 +582,7 @@ Err HeaderChecker::MakeUnreachableError(const InputFile& source_file,
 
   // Only display toolchains on labels if they don't all match.
   bool include_toolchain = !targets_with_other_toolchains.empty();
+  include_toolchain = true;
 
   std::string msg = "It is not in any dependency of\n  " +
                     from_target->label().GetUserVisibleName(include_toolchain);

--- a/tools/gn/header_checker.cc
+++ b/tools/gn/header_checker.cc
@@ -582,7 +582,6 @@ Err HeaderChecker::MakeUnreachableError(const InputFile& source_file,
 
   // Only display toolchains on labels if they don't all match.
   bool include_toolchain = !targets_with_other_toolchains.empty();
-  include_toolchain = true;
 
   std::string msg = "It is not in any dependency of\n  " +
                     from_target->label().GetUserVisibleName(include_toolchain);

--- a/tools/gn/jumbo_file_list_generator.cc
+++ b/tools/gn/jumbo_file_list_generator.cc
@@ -31,9 +31,6 @@ std::string GetJumboFileName(const std::string& target_name,
     case SOURCE_MM:
       extension = "mm";
       break;
-    case SOURCE_S:
-      extension = "s";
-      break;
     default:
       return std::string();
   }
@@ -64,7 +61,7 @@ void JumboFileListGenerator::Run() {
   for (const SourceFile& input : target_->sources()) {
     SourceFileType file_type = GetSourceFileType(input);
     if (file_type != SOURCE_C && file_type != SOURCE_CPP &&
-        file_type != SOURCE_MM && file_type != SOURCE_S) {
+        file_type != SOURCE_MM) {
       continue;
     }
 


### PR DESCRIPTION
The support for S files was a contribution that was accepted because
I didn't know that it wouldn't work. Now I know so it has to go. Bye.